### PR TITLE
Feature - Making use of composer's replace feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "replace": {
+      "php-activerecord/php-activerecord": "~1.1.0"
+    },
     "autoload": {
         "files": [ "ActiveRecord.php" ]
     }


### PR DESCRIPTION
As described in: https://getcomposer.org/doc/04-schema.md#replace

We're making use of the `replace` feature in the `composer.json`. This will allow other packages that depend on the original `php-activerecord/php-activerecord` to "replace" it with the `robinpowered/php-activerecord` package.
