### PR TITLE
Chore: Docblock fixes

### DIFF
--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -1,6 +1,5 @@
 <?php
 namespace ActiveRecord;
-use Closure;
 
 /**
  * Cache::get('the-cache-key', function() {

--- a/lib/CallBack.php
+++ b/lib/CallBack.php
@@ -151,9 +151,8 @@ class CallBack
 	 * @param string $model Model to invoke the callback on.
 	 * @param string $name Name of the callback to invoke
 	 * @param boolean $must_exist Set to true to raise an exception if the callback does not exist.
-	 * @return mixed null if $name was not a valid callback type or false if a method was invoked
-	 * that was for a before_* callback and that method returned false. If this happens, execution
-	 * of any other callbacks after the offending callback will not occur.
+	 * @return bool false if a method was invoked that was for a before_* callback and that method returned false.
+	 * If this happens, execution of any other callbacks after the offending callback will not occur.
 	 */
 	public function invoke($model, $name, $must_exist=true)
 	{

--- a/lib/CallBack.php
+++ b/lib/CallBack.php
@@ -105,7 +105,6 @@ class CallBack
 	 * Creates a CallBack.
 	 *
 	 * @param string $model_class_name The name of a {@link Model} class
-	 * @return CallBack
 	 */
 	public function __construct($model_class_name)
 	{

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -120,7 +120,7 @@ class Config extends Singleton
 	 * @param array $connections Array of connections
 	 * @param string $default_connection Optionally specify the default_connection
 	 * @return void
-	 * @throws ActiveRecord\ConfigException
+	 * @throws \ActiveRecord\ConfigException
 	 */
 	public function set_connections($connections, $default_connection=null)
 	{

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -12,6 +12,7 @@ use PDO;
 use PDOException;
 use Closure;
 use PDOStatement;
+use stdClass;
 
 /**
  * The base class for database connection adapters.
@@ -161,7 +162,7 @@ abstract class Connection
 	 * </code>
 	 *
 	 * @param string $connection_url A connection URL
-	 * @return \stdClass the parsed URL as an object.
+	 * @return stdClass the parsed URL as an object.
 	 */
 	public static function parse_connection_url($connection_url)
 	{

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -11,6 +11,7 @@ require_once 'Column.php';
 use PDO;
 use PDOException;
 use Closure;
+use PDOStatement;
 
 /**
  * The base class for database connection adapters.
@@ -160,7 +161,7 @@ abstract class Connection
 	 * </code>
 	 *
 	 * @param string $connection_url A connection URL
-	 * @return object the parsed URL as an object.
+	 * @return \stdClass the parsed URL as an object.
 	 */
 	public static function parse_connection_url($connection_url)
 	{
@@ -297,7 +298,7 @@ abstract class Connection
 	 *
 	 * @param string $sql Raw SQL string to execute.
 	 * @param array &$values Optional array of bind values
-	 * @return mixed A result set object
+	 * @return PDOStatement A result set object
 	 */
 	public function query($sql, &$values=array())
 	{

--- a/lib/Exceptions.php
+++ b/lib/Exceptions.php
@@ -77,8 +77,8 @@ class UndefinedPropertyException extends ModelException
 	/**
 	 * Sets the exception message to show the undefined property's name.
 	 *
-	 * @param str $property_name name of undefined property
-	 * @return void
+	 * @param string $class_name The name of the class where the property isn't defined.
+	 * @param string $property_name name of undefined property
 	 */
 	public function __construct($class_name, $property_name)
 	{
@@ -105,7 +105,6 @@ class ReadOnlyException extends ModelException
 	 *
 	 * @param str $class_name name of the model that is read only
 	 * @param str $method_name name of method which attempted to modify the model
-	 * @return void
 	 */
 	public function __construct($class_name, $method_name)
 	{

--- a/lib/Exceptions.php
+++ b/lib/Exceptions.php
@@ -103,8 +103,8 @@ class ReadOnlyException extends ModelException
 	/**
 	 * Sets the exception message to show the undefined property's name.
 	 *
-	 * @param str $class_name name of the model that is read only
-	 * @param str $method_name name of method which attempted to modify the model
+	 * @param string $class_name name of the model that is read only
+	 * @param string $method_name name of method which attempted to modify the model
 	 */
 	public function __construct($class_name, $method_name)
 	{

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -235,7 +235,7 @@ class Model
 	 * Constructs a model.
 	 *
 	 * When a user instantiates a new object (e.g.: it was not ActiveRecord that instantiated via a find)
-	 * then <code>$attributes</code> be mapped according to the schema's defaults. Otherwise, the given
+	 * then $attributes be mapped according to the schema's defaults. Otherwise, the given
 	 * $attributes will be mapped via set_attributes_via_mass_assignment.
 	 *
 	 * <code>

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -3,6 +3,7 @@
  * @package ActiveRecord
  */
 namespace ActiveRecord;
+use Closure;
 
 /**
  * The base class for your models.
@@ -234,7 +235,7 @@ class Model
 	 * Constructs a model.
 	 *
 	 * When a user instantiates a new object (e.g.: it was not ActiveRecord that instantiated via a find)
-	 * then @var $attributes will be mapped according to the schema's defaults. Otherwise, the given
+	 * then <code>$attributes</code> be mapped according to the schema's defaults. Otherwise, the given
 	 * $attributes will be mapped via set_attributes_via_mass_assignment.
 	 *
 	 * <code>
@@ -571,7 +572,7 @@ class Model
 	/**
 	 * Retrieve the primary key name.
 	 *
-	 * @param boolean Set to true to return the first value in the pk array only
+	 * @param boolean $first Set to true to return the first value in the pk array only
 	 * @return string The primary key for the model
 	 */
 	public function get_primary_key($first=false)
@@ -657,7 +658,7 @@ class Model
 	 *
 	 * @param string $name Name of an attribute
 	 * @param array $delegate An array containing delegate data
-	 * @return delegated attribute name or null
+	 * @return string|null delegated attribute name or null
 	 */
 	private function is_delegated($name, &$delegate)
 	{
@@ -693,7 +694,7 @@ class Model
 	/**
 	 * Throws an exception if this model is set to readonly.
 	 *
-	 * @throws ActiveRecord\ReadOnlyException
+	 * @throws \ActiveRecord\ReadOnlyException
 	 * @param string $method_name Name of method that was invoked on model for exception message
 	 */
 	private function verify_not_readonly($method_name)
@@ -1151,7 +1152,7 @@ class Model
 	/**
 	 * Passing $guard_attributes as true will throw an exception if an attribute does not exist.
 	 *
-	 * @throws ActiveRecord\UndefinedPropertyException
+	 * @throws \ActiveRecord\UndefinedPropertyException
 	 * @param array $attributes An array in the form array(name => value, ...)
 	 * @param boolean $guard_attributes Flag of whether or not protected/non-accessible attributes should be guarded
 	 */
@@ -1208,8 +1209,8 @@ class Model
 	 *
 	 * @internal This should <strong>only</strong> be used by eager load
 	 * @param Model $model
-	 * @param $name of relationship for this table
-	 * @return void
+	 * @param string $name of relationship for this table
+	 * @return Model|array
 	 */
 	public function set_relationship_from_eager_load(Model $model=null, $name)
 	{

--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -205,11 +205,11 @@ class SQLBuilder
 	 * Converts a string like "id_and_name_or_z" into a conditions value like array("id=? AND name=? OR z=?", values, ...).
 	 *
 	 * @param Connection $connection
-	 * @param $name Underscored string
+	 * @param string $name Underscored string
 	 * @param $values Array of values for the field names. This is used
 	 *   to determine what kind of bind marker to use: =?, IN(?), IS NULL
-	 * @param $map A hash of "mapped_column_name" => "real_column_name"
-	 * @return A conditions array in the form array(sql_string, value1, value2,...)
+	 * @param array $map A hash of "mapped_column_name" => "real_column_name"
+	 * @return array A conditions array in the form array(sql_string, value1, value2,...)
 	 */
 	public static function create_conditions_from_underscored_string(Connection $connection, $name, &$values=array(), &$map=null)
 	{
@@ -250,8 +250,8 @@ class SQLBuilder
 	 * Like create_conditions_from_underscored_string but returns a hash of name => value array instead.
 	 *
 	 * @param string $name A string containing attribute names connected with _and_ or _or_
-	 * @param $args Array of values for each attribute in $name
-	 * @param $map A hash of "mapped_column_name" => "real_column_name"
+	 * @param array $values Array of values for each attribute in $name
+	 * @param array $map A hash of "mapped_column_name" => "real_column_name"
 	 * @return array A hash of array(name => value, ...)
 	 */
 	public static function create_hash_from_underscored_string($name, &$values=array(), &$map=null)

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -292,7 +292,7 @@ class Table
 	 * @param $name string name of Relationship
 	 * @param $strict bool
 	 * @throws RelationshipException
-	 * @return Relationship or null
+	 * @return AbstractRelationship|null
 	 */
 	public function get_relationship($name, $strict=false)
 	{
@@ -352,7 +352,7 @@ class Table
 	/**
 	 * Add a relationship.
 	 *
-	 * @param Relationship $relationship a Relationship object
+	 * @param AbstractRelationship $relationship a Relationship object
 	 */
 	private function add_relationship($relationship)
 	{

--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -34,7 +34,7 @@
  */
 namespace ActiveRecord;
 
-use \Closure;
+use Closure;
 
 function classify($class_name, $singularize=false)
 {
@@ -117,7 +117,7 @@ function has_absolute_namespace($class_name)
  * Returns true if all values in $haystack === $needle
  * @param $needle
  * @param $haystack
- * @return unknown_type
+ * @return boolean
  */
 function all($needle, array $haystack)
 {


### PR DESCRIPTION
Fixes up docblocks, specifically @param and @return tags. Most of these were discovered by inspection tools in PHPStorm. 

The library is mixed on if it includes `@throws` tags, so I didn't add throws tag everywhere necessary. This PR strictly fixes incorrect types.
