### PR TITLE
Bugfix: `assign_attribute` timezone fix

### DIFF
--- a/lib/Column.php
+++ b/lib/Column.php
@@ -128,7 +128,10 @@ class Column
 					return $value;
 
 				if ($value instanceof \DateTime)
-					return new DateTime($value->format('Y-m-d H:i:s'), $value->getTimezone());
+					return new DateTime(
+						$value->format(Connection::DATETIME_TRANSLATE_FORMAT),
+						$value->getTimezone()
+					);
 
 				return $connection->string_to_datetime($value);
 		}

--- a/lib/Column.php
+++ b/lib/Column.php
@@ -128,7 +128,7 @@ class Column
 					return $value;
 
 				if ($value instanceof \DateTime)
-					return new DateTime($value->format('Y-m-d H:i:s T'));
+					return new DateTime($value->format('Y-m-d H:i:s'), $value->getTimezone());
 
 				return $connection->string_to_datetime($value);
 		}

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -21,6 +21,16 @@ use stdClass;
  */
 abstract class Connection
 {
+	/**
+	 * The DateTime format to use when translating other DateTime-compatible objects.
+  	 *
+  	 * NOTE: The DateTime "format" used must not include a time-zone (name, abbreviation, etc) or offset.
+  	 * Including one will cause PHP to ignore the passed in time-zone in the 3rd argument.
+  	 * See bug: https://bugs.php.net/bug.php?id=61022
+  	 *
+  	 * @var string
+  	 */
+  	const DATETIME_TRANSLATE_FORMAT = 'Y-m-d\TH:i:s';
 
 	/**
 	 * The PDO connection object.
@@ -481,7 +491,10 @@ abstract class Connection
 		if ($errors['warning_count'] > 0 || $errors['error_count'] > 0)
 			return null;
 
-		return new DateTime($date->format(static::$datetime_format));
+		return new DateTime(
+			$date->format(static::DATETIME_TRANSLATE_FORMAT),
+			$date->getTimezone()
+		);
 	}
 
 	/**

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -450,7 +450,7 @@ class Model
 
 		// convert php's \DateTime to ours
 		if ($value instanceof \DateTime)
-			$value = new DateTime($value->format('Y-m-d H:i:s'), $value->getTimezone());
+			$value = new DateTime($value->format(Connection::DATETIME_TRANSLATE_FORMAT), $value->getTimezone());
 
 		// make sure DateTime values know what model they belong to so
 		// dirty stuff works when calling set methods on the DateTime object

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -4,7 +4,6 @@
  */
 namespace ActiveRecord;
 use Closure;
-use DateTimeZone;
 
 /**
  * The base class for your models.
@@ -451,7 +450,7 @@ class Model
 
 		// convert php's \DateTime to ours
 		if ($value instanceof \DateTime)
-			$value = new DateTime($value->format('Y-m-d H:i:s'), new DateTimeZone($value->getTimezone()->getName()));
+			$value = new DateTime($value->format('Y-m-d H:i:s'), $value->getTimezone());
 
 		// make sure DateTime values know what model they belong to so
 		// dirty stuff works when calling set methods on the DateTime object

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -4,6 +4,7 @@
  */
 namespace ActiveRecord;
 use Closure;
+use DateTimeZone;
 
 /**
  * The base class for your models.
@@ -450,7 +451,7 @@ class Model
 
 		// convert php's \DateTime to ours
 		if ($value instanceof \DateTime)
-			$value = new DateTime($value->format('Y-m-d H:i:s T'));
+			$value = new DateTime($value->format('Y-m-d H:i:s'), new DateTimeZone($value->getTimezone()->getName()));
 
 		// make sure DateTime values know what model they belong to so
 		// dirty stuff works when calling set methods on the DateTime object


### PR DESCRIPTION
This PR fixes a bug with PHP-activerecord where when assigning a datetime, it always changes it to an `ActiveRecord\DateTime`, but in doing so loses timezone information.

This is because it uses a serialized date format with `T`, which represents a timezone abbreviation. However these can be ambiguous, such as with `IST` or `CST`, causing the actual `DateTime` value to be incorrect.

This was attempted to be fixed in the upstream repository and probably will be repaired soon:

Original Issue: https://github.com/jpfuentes2/php-activerecord/issues/520

PRs:
https://github.com/jpfuentes2/php-activerecord/pull/533 (fixed it)
https://github.com/jpfuentes2/php-activerecord/pull/532 (unfixed it)
