### PR TITLE
Bugfix - DateTime method overrides

### DIFF
--- a/lib/DateTime.php
+++ b/lib/DateTime.php
@@ -84,7 +84,7 @@ class DateTime extends \DateTime
 	 * @param string $format A format string accepted by get_format()
 	 * @return string formatted date and time string
 	 */
-	public function format($format=null)
+	public function format($format = null)
 	{
 		return parent::format(self::get_format($format));
 	}
@@ -99,15 +99,17 @@ class DateTime extends \DateTime
 	 * @param string $format A pre-defined string format or a raw format string
 	 * @return string a format string
 	 */
-	public static function get_format($format=null)
+	public static function get_format($format = null)
 	{
 		// use default format if no format specified
-		if (!$format)
+		if (!$format) {
 			$format = self::$DEFAULT_FORMAT;
+		}
 
 		// format is a friendly
-		if (array_key_exists($format, self::$FORMATS))
+		if (array_key_exists($format, self::$FORMATS)) {
 			 return self::$FORMATS[$format];
+		}
 
 		// raw format
 		return $format;
@@ -120,8 +122,9 @@ class DateTime extends \DateTime
 
 	private function flag_dirty()
 	{
-		if ($this->model)
+		if ($this->model) {
 			$this->model->flag_dirty($this->attribute_name);
+		}
 	}
 
 	public function setDate($year, $month, $day)
@@ -130,7 +133,7 @@ class DateTime extends \DateTime
 		return parent::setDate($year, $month, $day);
 	}
 
-	public function setISODate($year, $week , $day = 1)
+	public function setISODate($year, $week, $day = 1)
 	{
 		$this->flag_dirty();
 		return parent::setISODate($year, $week, $day);
@@ -153,13 +156,13 @@ class DateTime extends \DateTime
 		$this->flag_dirty();
 		return parent::setTimezone($timezone);
 	}
-	
+
 	public function modify($modify)
 	{
 		$this->flag_dirty();
 		return parent::modify($modify);
 	}
-	
+
 	public function add($interval)
 	{
 		$this->flag_dirty();
@@ -171,5 +174,4 @@ class DateTime extends \DateTime
 		$this->flag_dirty();
 		return parent::sub($interval);
 	}
-
 }

--- a/lib/DateTime.php
+++ b/lib/DateTime.php
@@ -127,25 +127,49 @@ class DateTime extends \DateTime
 	public function setDate($year, $month, $day)
 	{
 		$this->flag_dirty();
-		call_user_func_array(array($this,'parent::setDate'),func_get_args());
+		return parent::setDate($year, $month, $day);
 	}
 
-	public function setISODate($year, $week , $day=null)
+	public function setISODate($year, $week , $day = 1)
 	{
 		$this->flag_dirty();
-		call_user_func_array(array($this,'parent::setISODate'),func_get_args());
+		return parent::setISODate($year, $week, $day);
 	}
 
-	public function setTime($hour, $minute, $second=null)
+	public function setTime($hour, $minute, $second = 0)
 	{
 		$this->flag_dirty();
-		call_user_func_array(array($this,'parent::setTime'),func_get_args());
+		return parent::setTime($hour, $minute, $second);
 	}
 
 	public function setTimestamp($unixtimestamp)
 	{
 		$this->flag_dirty();
-		call_user_func_array(array($this,'parent::setTimestamp'),func_get_args());
+		return parent::setTimestamp($unixtimestamp);
 	}
+
+	public function setTimezone($timezone)
+	{
+		$this->flag_dirty();
+		return parent::setTimezone($timezone);
+	}
+	
+	public function modify($modify)
+	{
+		$this->flag_dirty();
+		return parent::modify($modify);
+	}
+	
+	public function add($interval)
+	{
+		$this->flag_dirty();
+		return parent::add($interval);
+	}
+
+	public function sub($interval)
+	{
+		$this->flag_dirty();
+		return parent::sub($interval);
+	}
+
 }
-?>

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -34,10 +34,16 @@ class DateTimeTest extends SnakeCase_PHPUnit_Framework_TestCase
 
 	public function test_should_flag_the_attribute_dirty()
 	{
+		$interval = new DateInterval('PT1S');
+		$timezone = new DateTimeZone('America/New_York');
 		$this->assert_dirtifies('setDate',2001,1,1);
 		$this->assert_dirtifies('setISODate',2001,1);
 		$this->assert_dirtifies('setTime',1,1);
 		$this->assert_dirtifies('setTimestamp',1);
+		$this->assert_dirtifies('setTimezone',$timezone);
+		$this->assert_dirtifies('modify','+1 day');
+		$this->assert_dirtifies('add',$interval);
+		$this->assert_dirtifies('sub',$interval);
 	}
 
 	public function test_set_iso_date()


### PR DESCRIPTION
I just hit a **terrible** bug with `ActiveRecord\DateTime` not returning a value on `setTimestamp()`.

This PR fixes that issue, among others, by pulling in a commit made upstream in PR jpfuentes2/php-activerecord#530. I added some style fixes due to PHP-CodeSniffer being annoying too. 😆 
