### PR TITLE
Bugfix - DateTime cloning and model attribute dirty flagging

### DIFF
--- a/lib/DateTime.php
+++ b/lib/DateTime.php
@@ -120,6 +120,20 @@ class DateTime extends \DateTime
 		return $this->format();
 	}
 
+	/**
+	 * Handle PHP object `clone`.
+	 *
+	 * This makes sure that the object doesn't still flag an attached model as
+	 * dirty after cloning the DateTime object and making modifications to it.
+	 *
+	 * @return void
+	 */
+	public function __clone()
+	{
+		$this->model = null;
+		$this->attribute_name = null;
+	}
+
 	private function flag_dirty()
 	{
 		if ($this->model) {

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -1,7 +1,6 @@
 <?php
 use ActiveRecord\DatabaseException;
 use ActiveRecord\DateTime as DateTime;
-use DateInterval;
 
 class DateTimeTest extends SnakeCase_PHPUnit_Framework_TestCase
 {

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -148,16 +148,20 @@ class DateTimeTest extends SnakeCase_PHPUnit_Framework_TestCase
 
 		$cloned_datetime = clone $datetime;
 
+		// Assert initial state
 		$this->assert_false($model->attribute_is_dirty($model_attribute));
 
 		$cloned_datetime->add(new DateInterval('PT1S'));
 
+		// Assert that modifying the cloned object didn't flag the model
 		$this->assert_false($model->attribute_is_dirty($model_attribute));
 
 		$datetime->add(new DateInterval('PT1S'));
 
+		// Assert that modifying the model-attached object did flag the model
 		$this->assert_true($model->attribute_is_dirty($model_attribute));
 
+		// Assert that the dates are equal but not the same instance
 		$this->assert_equals($datetime, $cloned_datetime);
 		$this->assert_not_same($datetime, $cloned_datetime);
 	}

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -1,6 +1,7 @@
 <?php
-use ActiveRecord\DateTime as DateTime;
 use ActiveRecord\DatabaseException;
+use ActiveRecord\DateTime as DateTime;
+use DateInterval;
 
 class DateTimeTest extends SnakeCase_PHPUnit_Framework_TestCase
 {
@@ -15,13 +16,20 @@ class DateTimeTest extends SnakeCase_PHPUnit_Framework_TestCase
 		DateTime::$DEFAULT_FORMAT = $this->original_format;
 	}
 
-	private function assert_dirtifies($method /*, method params, ...*/)
+	private function get_model()
 	{
 		try {
 			$model = new Author();
 		} catch (DatabaseException $e) {
 			$this->mark_test_skipped('failed to connect. '.$e->getMessage());
 		}
+
+		return $model;
+	}
+
+	private function assert_dirtifies($method /*, method params, ...*/)
+	{
+		$model = $this->get_model();
 		$datetime = new DateTime();
 		$datetime->attribute_of($model,'some_date');
 
@@ -128,6 +136,30 @@ class DateTimeTest extends SnakeCase_PHPUnit_Framework_TestCase
 	public function test_to_string()
 	{
 		$this->assert_equals(date(DateTime::get_format()), "" . $this->date);
+	}
+
+	public function test_clone()
+	{
+		$model = $this->get_model();
+		$model_attribute = 'some_date';
+
+		$datetime = new DateTime();
+		$datetime->attribute_of($model, $model_attribute);
+
+		$cloned_datetime = clone $datetime;
+
+		$this->assert_false($model->attribute_is_dirty($model_attribute));
+
+		$cloned_datetime->add(new DateInterval('PT1S'));
+
+		$this->assert_false($model->attribute_is_dirty($model_attribute));
+
+		$datetime->add(new DateInterval('PT1S'));
+
+		$this->assert_true($model->attribute_is_dirty($model_attribute));
+
+		$this->assert_equals($datetime, $cloned_datetime);
+		$this->assert_not_same($datetime, $cloned_datetime);
 	}
 }
 ?>


### PR DESCRIPTION
This is a `robin-master` rebasing of the same PR made to upstream jpfuentes2/php-activerecord#541. Included is the description from the upstream PR:

> Another day, another `ActiveRecord\DateTime` bug. 😞
> 
> PHP's native `DateTime` object (what `ActiveRecord\DateTime` extends) is a mutable object, so it's a common practice to `clone` them to make modifications and comparisons based on the same initial value ([in fact, this is what `phpunit` does internally](https://github.com/sebastianbergmann/comparator/blob/1.2.0/src/DateTimeComparator.php#L50-L51)).
> 
> Unfortunately, when cloning an `ActiveRecord\DateTime` object that has an attached model reference in the current PHP-ActiveRecord library, you end up keeping that reference around in the clone. The problem with that is if you're intending to clone the `ActiveRecord\DateTime` object to make comparisons by modifying the value, you'll end up flagging the still-referenced model as dirty even though that `ActiveRecord\DateTime` object is no longer the actual instance in the model. This becomes even more of a problem when you consider how native `DateTime` objects are transparently transformed into `ActiveRecord\DateTime` objects upon setting them to a model's attribute.
> 
> This PR fixes that issue by making use of PHP's `__clone()` method that allows us to control the state of the new object after it's been cloned. More info on cloning in PHP is available on the manual: http://php.net/manual/en/language.oop5.cloning.php
> 
> I've included a test that should prove the expected behavior. TDD FTW.
