### PR TITLE
Feature: Faster Eager Loading

### DIFF
--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -180,33 +180,35 @@ abstract class AbstractRelationship implements InterfaceRelationship
 		$class = $this->class_name;
 
 		$related_models = $class::find('all', $options);
-		$used_models = array();
+		$used_models_map = array();
+		$related_models_map = array();
 		$model_values_key = $inflector->variablize($model_values_key);
 		$query_key = $inflector->variablize($query_key);
 
+		foreach ($related_models as $related)
+		{
+			$related_models_map[$related->$query_key][] = $related;
+		}
+
 		foreach ($models as $model)
 		{
-			$matches = 0;
 			$key_to_match = $model->$model_values_key;
 
-			foreach ($related_models as $related)
-			{
-				if ($related->$query_key == $key_to_match)
+			if (isset($related_models_map[$key_to_match])) {
+				foreach ($related_models_map[$key_to_match] as $related)
 				{
 					$hash = spl_object_hash($related);
 
-					if (in_array($hash, $used_models))
+					if (isset($used_models_map[$hash]))
 						$model->set_relationship_from_eager_load(clone($related), $this->attribute_name);
 					else
 						$model->set_relationship_from_eager_load($related, $this->attribute_name);
 
-					$used_models[] = $hash;
-					$matches++;
+					$used_models_map[$hash] = $hash;
 				}
-			}
-
-			if (0 === $matches)
+			} else {
 				$model->set_relationship_from_eager_load(null, $this->attribute_name);
+			}
 		}
 	}
 

--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -204,7 +204,7 @@ abstract class AbstractRelationship implements InterfaceRelationship
 					else
 						$model->set_relationship_from_eager_load($related, $this->attribute_name);
 
-					$used_models_map[$hash] = $hash;
+					$used_models_map[$hash] = true;
 				}
 			} else {
 				$model->set_relationship_from_eager_load(null, $this->attribute_name);


### PR DESCRIPTION
This PR improves the logic of eager loading, especially when eager loading a lot of related models.

The existing code would loop through each model that was being eager loaded onto and then (nested) loop through all the possible related models to add those relationships.

The new approach first maps all the related models by their keys so that in the second loop they are easily accessible without traversing the entire array.

My big O notation is rusty, but I think this is roughly--
Previously: `O(n*m)` 
Now: `O(m) + O(n*log(m))`

..but actually a little bit better cause we also improved the `$used_model` array to be a map as well.

I first noticed that this took a while when dealing with an eager load that loaded ~200 models onto 10 results. Anecdotally on my local machine, this took that from a 400ms task to about 150ms (it still took 150ms to instantiate the 200 models, but that's a separate issue).
