### PR TITLE
Enhancement - Query logger refactor

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -8,6 +8,7 @@ if (!defined('PHP_ACTIVERECORD_AUTOLOAD_PREPEND'))
 	define('PHP_ACTIVERECORD_AUTOLOAD_PREPEND',true);
 
 require __DIR__.'/lib/Singleton.php';
+require __DIR__.'/lib/Logger.php';
 require __DIR__.'/lib/Config.php';
 require __DIR__.'/lib/Utils.php';
 require __DIR__.'/lib/DateTime.php';

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,11 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "4.*",
+        "pear/pear_exception": "1.0-beta1",
+        "pear/log": "~1.12"
+    },
     "replace": {
       "php-activerecord/php-activerecord": "~1.1.0"
     },

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -228,17 +228,12 @@ class Config extends Singleton
 	/**
 	 * Sets the logger object for future SQL logging
 	 *
-	 * @param object $logger
+	 * @param Logger $logger
 	 * @return void
 	 * @throws ConfigException if Logger objecct does not implement public log()
 	 */
-	public function set_logger($logger)
+	public function set_logger(Logger $logger)
 	{
-		$klass = Reflections::instance()->add($logger)->get($logger);
-
-		if (!$klass->getMethod('log') || !$klass->getMethod('log')->isPublic())
-			throw new ConfigException("Logger object must implement a public log method");
-
 		$this->logger = $logger;
 	}
 
@@ -255,7 +250,7 @@ class Config extends Singleton
 	/**
 	 * Returns the logger
 	 *
-	 * @return object
+	 * @return Logger
 	 */
 	public function get_logger()
 	{

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -66,9 +66,9 @@ class Config extends Singleton
 	private $logging = false;
 
 	/**
-	 * Contains a Logger object that must impelement a log() method.
+	 * Contains a query logger.
 	 *
-	 * @var object
+	 * @var Logger
 	 */
 	private $logger;
 
@@ -230,7 +230,6 @@ class Config extends Singleton
 	 *
 	 * @param Logger $logger
 	 * @return void
-	 * @throws ConfigException if Logger objecct does not implement public log()
 	 */
 	public function set_logger(Logger $logger)
 	{

--- a/lib/Logger.php
+++ b/lib/Logger.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @package ActiveRecord
+ */
+namespace ActiveRecord;
+
+/**
+ * Defines a logger for logging queries.
+ *
+ * @package ActiveRecord
+ */
+interface Logger
+{
+
+	/**
+	 * Logs a message.
+	 *
+	 * Implementations should expect that `done()` will be called after a call
+	 * to this method, for logged SQL queries.
+	 *
+	 * @param string $message The message to log.
+	 * @param array $params Any parameters associated with the message.
+	 * @return void
+	 */
+	public function log($message, array $params = null);
+
+	/**
+	 * Signals that a previous log context (started via `log()`) is finished.
+	 *
+	 * This is useful for logging the elapsed time of a SQL query.
+	 *
+	 * @return void
+	 */
+	public function done();
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,2 +1,18 @@
-<phpunit bootstrap="test/helpers/config.php">
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="test/helpers/config.php"
+>
+    <testsuites>
+        <testsuite name="PHP ActiveRecord Test Suite">
+            <directory>./test/</directory>
+        </testsuite>
+    </testsuites>
 </phpunit>

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -3,7 +3,7 @@
 use ActiveRecord\Config;
 use ActiveRecord\ConfigException;
 
-class TestLogger
+class NoOpTestLogger
 {
 	private function log() {}
 }
@@ -85,7 +85,7 @@ class ConfigTest extends SnakeCase_PHPUnit_Framework_TestCase
 	public function test_logger_object_must_implement_log_method()
 	{
 		try {
-			$this->config->set_logger(new TestLogger);
+			$this->config->set_logger(new NoOpTestLogger);
 			$this->fail();
 		} catch (ConfigException $e) {
 			$this->assert_equals($e->getMessage(), "Logger object must implement a public log method");

--- a/test/helpers/TestLogger.php
+++ b/test/helpers/TestLogger.php
@@ -1,0 +1,26 @@
+<?php
+
+use ActiveRecord\Logger;
+
+final class TestLogger implements Logger
+{
+
+    private $delegate;
+
+    public function __construct(Log_file $delegate)
+    {
+        $this->delegate = $delegate;
+    }
+
+    public function log($message, array $params = null)
+    {
+        $this->delegate->log(
+            sprintf('%s (with values: %s)', $message, var_export($params, true))
+        );
+    }
+
+    public function done()
+    {
+        // No-op
+    }
+}

--- a/test/helpers/config.php
+++ b/test/helpers/config.php
@@ -1,18 +1,23 @@
 <?php
 /**
- * In order to run these unit tests, you need to install:
- *  - PHPUnit
- *  - PEAR Log (otherwise logging SQL queries will be disabled)
- *  - Memcache (otherwise Caching tests will not be executed)
- *  
- * To run all tests : phpunit AllTests.php --slow-tests
- * To run a specific test : phpunit ????Test.php 
- */
-
-@include_once 'Log.php';
-@include_once 'Log/file.php';
-require_once 'PHPUnit/Framework/TestCase.php';
+ * In order to run these unit tests, you need to install the required packages using Composer:
+ *
+ *    $ composer install
+ *
+ * After that you can run the tests by invoking the local PHPUnit
+ *
+ * To run all test simply use:
+ *
+ *    $ vendor/bin/phpunit
+ *
+ * Or run a single test file by specifying its path:
+ *
+ *    $ vendor/bin/phpunit test/InflectorTest.php
+ *
+ **/
+require_once 'vendor/autoload.php';
 require_once 'SnakeCase_PHPUnit_Framework_TestCase.php';
+require_once 'TestLogger.php';
 require_once 'DatabaseTest.php';
 require_once 'AdapterTest.php';
 require_once __DIR__ . '/../../ActiveRecord.php';
@@ -48,7 +53,9 @@ ActiveRecord\Config::initialize(function($cfg)
 
 	if (class_exists('Log_file')) // PEAR Log installed
 	{
-		$logger = new Log_file(dirname(__FILE__) . '/../log/query.log','ident',array('mode' => 0664, 'timeFormat' =>  '%Y-%m-%d %H:%M:%S'));
+		$logger = new TestLogger(
+			new Log_file(dirname(__FILE__) . '/../log/query.log','ident',array('mode' => 0664, 'timeFormat' =>  '%Y-%m-%d %H:%M:%S'))
+		);
 	
 		$cfg->set_logging(true);
 		$cfg->set_logger($logger);


### PR DESCRIPTION
This PR refactors the query logger that's set in `Config` and used in the `Connection` classes.

Specifically, this refactor:

- Defines an actual interface for the logger, rather than relying on documentation, reflection method checking, and exception throwing. Yay strong typing!
- Changes the logger method from a single `log($message)` method to **two** methods that allow for contextual query logging, similar to the [Doctrine `SQLLogger`](https://github.com/doctrine/dbal/blob/v2.6.1/lib/Doctrine/DBAL/Logging/SQLLogger.php).
- Consolidates the awkward calls to the logger from 2 statements to 1 statement with contextual parameters, making it far easier to log meta about a query without having to use state-management workarounds.
- Simplifies the query time logging, as its now an implementation detail of the provided logger
- Updates tests to adapt to the new interface