### PR TITLE
Bugfix - Ensure we're only counting arrays

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1585,7 +1585,7 @@ class Model
 		$list = static::table()->find($options);
 		$results = count($list);
 
-		if ($results != ($expected = count($values)))
+		if ($results != ($expected = is_array($values) ? count($values) : 1))
 		{
 			$class = get_called_class();
 


### PR DESCRIPTION
Tiny PR to help with PHP 7.2's warning about non-countable types: https://www.php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types